### PR TITLE
PR to add non-HTTPS fallback for SAPNetWeaver collector provider as well as more granular latency logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.code-workspace
+settings.json
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/sapmon/payload/helper/timeutils.py
+++ b/sapmon/payload/helper/timeutils.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+#
+#       timeutils helper methods for working with time() objects for logging high precision latency
+
+#       License:        GNU General Public License (GPL)
+#       (c) 2020        Microsoft Corp.
+#
+
+# Python modules
+from time import time
+
+class TimeUtils:
+
+    @staticmethod
+    def getElapsedMilliseconds(startTime: float, endTime: float = None) -> int:
+        """
+        return number of milliseconds (as int) elapsed since the specified start time
+        (where start time is value returned from previous call to time.time())
+
+        if endTime is not specified, then will calculate elapsed against current Time()
+        """
+
+        if not endTime:
+            endTime = time()
+
+        return int((endTime - startTime) * 1000)

--- a/sapmon/payload/helper/timeutils.py
+++ b/sapmon/payload/helper/timeutils.py
@@ -24,3 +24,4 @@ class TimeUtils:
             endTime = time()
 
         return int((endTime - startTime) * 1000)
+        


### PR DESCRIPTION
PR against Harsha's subdomain feature branch to pull add a fallback to HTTP for SAPNetWeaver provider collector code if there is no valid HTTPS port configured for a given instance.  Also add some additional logging around remote dependency call latency so we can track how long these collector operations are taking.