### PR TITLE
Mfrei/ams fix exception stack trace logging and robustness around cached state 'hostConfig'

### DIFF
--- a/sapmon/payload/helper/tracing.py
+++ b/sapmon/payload/helper/tracing.py
@@ -54,7 +54,7 @@ class JsonFormatter(logging.Formatter):
          jsonContent.append(("msg", formattedMsg))
 
          if record.exc_info:
-            jsonContent.append(("stackTrace", traceback.format_stack()))
+            jsonContent.append(("exceptionStackTrace", self.formatException(record.exc_info)))
 
          # An OrderedDict is used to ensure that the converted data appears in the same order for every record
          return OrderedDict(jsonContent)


### PR DESCRIPTION
Fix issue with queue based logger JsonFormatter so that the stack trace that is logged when log call contains an exception is the actual stack of the exception, not of the log API call.  We needed this change to actually debug a different customer issue, where a specific customer is getting a variety of "NoneType has no len()" or "NoneType is not iterable" exceptions from various parts of code.  After getting correct exception stack traces, it appears this customer has a null hostConfig cached in their provider state, which exposed several different robustness issues in the code where this was always expected to have a non-null value. 